### PR TITLE
Fix Docker build: install all dependencies including devDependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci --only=production
+RUN npm ci
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
- Change npm ci --only=production to npm ci to include Vite and build tools
- Required for successful npm run build during Docker build process

🤖 Generated with [Claude Code](https://claude.ai/code)