### PR TITLE
Fix nginx configuration: remove invalid must-revalidate value

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,7 +8,7 @@ server {
     gzip on;
     gzip_vary on;
     gzip_min_length 1024;
-    gzip_proxied expired no-cache no-store private must-revalidate auth;
+    gzip_proxied expired no-cache no-store private auth;
     gzip_types
         text/plain
         text/css


### PR DESCRIPTION
- Remove 'must-revalidate' from gzip_proxied directive as it's not valid for nginx
- Keep other valid gzip proxy conditions

🤖 Generated with [Claude Code](https://claude.ai/code)